### PR TITLE
set find-file defalut directory

### DIFF
--- a/init.el
+++ b/init.el
@@ -92,6 +92,14 @@
     :custom ((auto-package-update-prompt-before-update . t))
     :hook (auto-package-update-before-hook . (lambda () (message "I will update packages now")))
     )
+  (leaf macos
+    :config
+    (leaf find-file-default-directory
+      :when (eq system-type 'darwin)
+      :emacs= 27.1
+      :custom ((default-directory . "~")
+	       (command-line-default-directory . "~/")))
+    )
   :hook (after-save-hook . executable-make-buffer-file-executable-if-script-p)
   :custom ((read-file-name-completion-ignore-case . t))
   :bind (("C-z" . nil)) ; C-z を無効にする


### PR DESCRIPTION
MacOS, 27.1 で `find-file` のデフォルトディレクトリが `/` になってしまった

27.2 で治るらしいので、それまでは明示的にデフォルトディレクトリを設定しておく。

https://apple.stackexchange.com/questions/399187/how-to-set-default-directory-for-emacs-27-1-app